### PR TITLE
Fix failed transaction due to unclosed recordsets

### DIFF
--- a/README.md
+++ b/README.md
@@ -279,9 +279,11 @@ Let's now look at some important log statements we will get as the response for 
 INFO  [banking_application] - Transfer $300 from Alice's account to Bob's account 
 INFO  [banking_application] - Expected: Transaction to be successful 
 INFO  [banking_application] - Initiating transaction 
+INFO  [banking_application] - Verifying whether account ID 1 exists
 INFO  [banking_application] - Available balance in account ID 1: 500
 INFO  [banking_application] - Withdrawing money from account ID: 1 
 INFO  [banking_application] - $300 has been withdrawn from account ID 1 
+INFO  [banking_application] - Verifying whether account ID 2 exists
 INFO  [banking_application] - Depositing money to account ID: 2 
 INFO  [banking_application] - $300 has been deposited to account ID 2 
 INFO  [banking_application] - Transaction committed 
@@ -295,9 +297,11 @@ INFO  [banking_application] - Successfully transferred $300 from account ID 1 to
 INFO  [banking_application] - Again try to transfer $500 from Alice's account to Bob's account
 INFO  [banking_application] - Expected: Transaction to fail as Alice now only has a balance of $200 in account
 INFO  [banking_application] - Initiating transaction 
+INFO  [banking_application] - Verifying whether account ID 1 exists
 INFO  [banking_application] - Available balance in account ID 1: 200
-INFO  [banking_application] - Error while withdrawing the money: Error: Not enough balance
-INFO  [banking_application] - Failed to transfer money from account ID 1 to account ID 2
+ERROR [banking_application] - Error while withdrawing the money: Error: Not enough balance
+ERROR [banking_application] - Failed to transfer money from account ID 1 to account ID 2
+INFO  [banking_application] - Transaction aborted
 ```
 
 - For the `scenario 3` where 'Bob' tries to transfer $500 to account ID 1234, the transaction is expected to fail as account ID 1234 does not exist
@@ -307,14 +311,15 @@ INFO  [banking_application] - Failed to transfer money from account ID 1 to acco
 INFO  [banking_application] - Try to transfer $500 from Bob's account to a non existing account ID
 INFO  [banking_application] - Expected: Transaction to fail as account ID of recipient is invalid
 INFO  [banking_application] - Initiating transaction 
-INFO  [banking_application] - vailable balance in account ID 2: 1300
+INFO  [banking_application] - Verifying whether account ID 2 exists
+INFO  [banking_application] - Available balance in account ID 2: 1300
 INFO  [banking_application] - Withdrawing money from account ID: 2 
 INFO  [banking_application] - $500 has been withdrawn from account ID 2 
-INFO  [banking_application] - Depositing money to account ID: 1234 
 INFO  [banking_application] - Verifying whether account ID 1234 exists 
 ERROR [banking_application] - Error while depositing the money: Error: Account does not exist
-INFO  [banking_application] - Failed to transfer money from account ID 2 to account ID 1234
+ERROR [banking_application] - Failed to transfer money from account ID 2 to account ID 1234
 INFO  [banking_application] - Check balance for Bob's account
+INFO  [banking_application] - Verifying whether account ID 2 exists
 INFO  [banking_application] - Available balance in account ID 2: 1300
 INFO  [banking_application] - You should see $1300 balance in Bob's account (NOT $800)
 INFO  [banking_application] - Explanation: 

--- a/guide/banking_application/account_manager.bal
+++ b/guide/banking_application/account_manager.bal
@@ -37,7 +37,7 @@ public function createAccount(string name) returns (int) {
     // Get the primary key of the last insertion (Auto incremented value).
     table dt = check bankDB->select("SELECT LAST_INSERT_ID() AS ACCOUNT_ID from ACCOUNT where ?", (), 1);
     // convert the table to json - Failure will not happen in this case; Hence omitting the error handling.
-    var jsonResult = check <json>dt;
+    json jsonResult = check <json>dt;
     // convert the json to int - Failure will not happen in this case; Hence omitting the error handling.
     match jsonResult[0]["ACCOUNT_ID"] {
         int intVal => accId = intVal;
@@ -56,7 +56,7 @@ public function verifyAccount(int accId) returns (boolean) {
     // Select query to check whether account exists.
     table dt = check bankDB->select("SELECT COUNT(*) AS COUNT FROM ACCOUNT WHERE ID = ?", (), accId);
     // convert the table to json - Failure will not happen in this case; Hence omitting the error handling.
-    var jsonResult = check <json>dt;
+    json jsonResult = check <json>dt;
     boolean isAccountExists = false;
     // convert the json to int - Failure will not happen in this case; Hence omitting the error handling.
     match jsonResult[0]["COUNT"] {
@@ -79,7 +79,7 @@ public function checkBalance(int accId) returns (int|error) {
     // Select query to get balance.
     table dt = check bankDB->select("SELECT BALANCE FROM ACCOUNT WHERE ID = ?", (), accId);
     // convert the table to json - Failure will not happen in this case; Hence omitting the error handling.
-    var jsonResult = check <json>dt;
+    json jsonResult = check <json>dt;
     // convert the json to int - Failure will not happen in this case; Hence omitting the error handling.
     match jsonResult[0]["BALANCE"] {
         int intVal => balance = intVal;

--- a/guide/banking_application/account_manager.bal
+++ b/guide/banking_application/account_manager.bal
@@ -45,6 +45,7 @@ public function createAccount(string name) returns (int) {
     }
     log:printInfo("Account ID for user: '" + name + "': " + accId);
     // Return the primary key, which will be the account number of the account.
+    dt.close();
     return accId;
 }
 
@@ -56,12 +57,15 @@ public function verifyAccount(int accId) returns (boolean) {
     table dt = check bankDB->select("SELECT COUNT(*) AS COUNT FROM ACCOUNT WHERE ID = ?", (), accId);
     // convert the table to json - Failure will not happen in this case; Hence omitting the error handling.
     var jsonResult = check <json>dt;
+    boolean isAccountExists = false;
     // convert the json to int - Failure will not happen in this case; Hence omitting the error handling.
     match jsonResult[0]["COUNT"] {
         // Return a boolean, which will be true if account exists; false otherwise.
-        int count => return <boolean>count;
-        any otherVals => return false;
+        int count => isAccountExists =  <boolean>count;
+        any otherVals => isAccountExists = false;
     }
+    dt.close();
+    return isAccountExists;
 }
 
 // Function to check balance in an account.
@@ -83,6 +87,7 @@ public function checkBalance(int accId) returns (int|error) {
     }
     log:printInfo("Available balance in account ID " + accId + ": " + balance);
     // Return the balance.
+    dt.close();
     return balance;
 }
 
@@ -169,10 +174,10 @@ public function transferMoney(int fromAccId, int toAccId, int amount) returns (b
 
 // Printed oncommit
 function commitFunc(string transactionId) {
-    log:printInfo("Transaction: " + transactionId + " aborted");
+    log:printInfo("Transaction: " + transactionId + " committed");
 }
 
 // Printed onabort
 function abortFunc(string transactionId) {
-    log:printInfo("Transaction: " + transactionId + " committed");
+    log:printInfo("Transaction: " + transactionId + " aborted");
 }

--- a/guide/banking_application/application.bal
+++ b/guide/banking_application/application.bal
@@ -16,7 +16,7 @@
 
 import ballerina/log;
 
-function main (string... args) {
+public function main (string... args) {
     log:printInfo("----------------------------------------------------------------------------------");
     // Create two new accounts
     log:printInfo("Create two new accounts for users 'Alice' and 'Bob'");


### PR DESCRIPTION
## Purpose

Database transactions are failed with error [1]. This was due to active recordsets due to unclosed tables which were used to read the data from the database. After properly closing the data tables, the issue got fixed.

But that will provide overhead to the developer to close the table. It will be better to close the data table implicitly by the code after selecting data.

[1] [2018-09-26 18:15:15,889] ERROR {org.ballerinalang.util.transactions.TransactionResourceManager} - error in abort the transaction, 0efff304-1bb3-410f-8d0d-415bc82a42e6:1:transaction rollback failed:Streaming result set com.mysql.jdbc.RowDataDynamic@5aa62ee7 is still active. No statements may be issued when any streaming result sets are open and in use on a given connection. Ensure that you have called .close() on any active streaming result sets before attempting more queries. 
org.ballerinalang.util.exceptions.BallerinaException: transaction rollback failed:Streaming result set com.mysql.jdbc.RowDataDynamic@5aa62ee7 is still active. No statements may be issued when any streaming result sets are open and in use on a given connection. Ensure that you have called .close() on any active streaming result sets before attempting more queries.
	